### PR TITLE
MNT: Use noarch python {{ python_min }} variable

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @areinsvo @chrisburr @henryiii @lgray @mcremone @nsmith-
+* @areinsvo @chrisburr @conda-forge/scikit-hep @henryiii @lgray @mcremone @nsmith-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Package license: BSD-3-Clause
 
 Summary: Tools for doing Collider HEP style analysis with columnar operations
 
+Development: https://github.com/CoffeaTeam/coffea
+
+Documentation: https://coffeateam.github.io/coffea/
+
 Current build status
 ====================
 
@@ -145,6 +149,7 @@ Feedstock Maintainers
 
 * [@areinsvo](https://github.com/areinsvo/)
 * [@chrisburr](https://github.com/chrisburr/)
+* [@conda-forge/scikit-hep](https://github.com/orgs/conda-forge/teams/scikit-hep/)
 * [@henryiii](https://github.com/henryiii/)
 * [@lgray](https://github.com/lgray/)
 * [@mcremone](https://github.com/mcremone/)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: Tools for doing Collider HEP style analysis with columnar operations
 
 Development: https://github.com/CoffeaTeam/coffea
 
-Documentation: https://coffeateam.github.io/coffea/
+Documentation: https://coffea-hep.readthedocs.io/
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "coffea" %}
 {% set version = "2024.10.0" %}
+{% set python_min = "3.9" %}
+# v2024.10.0 supports Python 3.8, but the required dependencies are missing
+# Python 3.8 support on conda-forge.
 
 
 package:
@@ -7,22 +10,22 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/coffea-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/coffea-{{ version }}.tar.gz
   sha256: 2b4d44faf39c9ad7e66a60abdb3ee4248539fb3c49be075ef7339178df95a23c
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python {{ python_min }}
     - hatchling >=1.17.1
     - hatch-vcs
     - pip
   run:
-    - python >=3.8
+    - python >={{ python_min }}
     - awkward >=2.6.7
     - uproot >=5.3.11
     - dask-core >=2024.3.0
@@ -31,6 +34,7 @@ requirements:
     - vector >=1.4.1
     - correctionlib >=2.6.0
     - pyarrow >=6.0.0
+    - fsspec-xrootd >=0.2.3
     - matplotlib-base >=3
     - numba >=0.58.1
     - numpy >=1.22.0
@@ -44,18 +48,25 @@ requirements:
     - pandas
     - hist >=2
     - cachetools
+    - requests
+    - aiohttp
 
 test:
+  requires:
+    - python {{ python_min }}
+    - pip
   imports:
     - coffea
-  requires:
-    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/CoffeaTeam/coffea
   summary: Tools for doing Collider HEP style analysis with columnar operations
   license: BSD-3-Clause
   license_file: LICENSE
+  doc_url: https://coffea-hep.readthedocs.io/
+  dev_url: https://github.com/CoffeaTeam/coffea
 
 extra:
   recipe-maintainers:
@@ -65,3 +76,4 @@ extra:
     - mcremone
     - chrisburr
     - henryiii
+    - conda-forge/scikit-hep


### PR DESCRIPTION
Resolves https://github.com/conda-forge/coffea-feedstock/issues/42

* Use 'python {{ python_min }}' syntax for the python requirements for noarch python recipes.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Use a Jinja2 set statement for python_min to keep all the build metadata contained in the recipe/meta.yaml and override the global python_min with coffea's python_min of 3.9.
   - coffea v2024.10.0 reports a minimum Python of 3.8, but the dependencies on conda-forge are unable to install without Python 3.9+.
* Remove --no-deps --no-build-isolation 'pip install' options in recipes as the build tool (e.g. conda-build, rattler-build) will enforce all required 'pip install' options itself at build time.
   - c.f. https://github.com/conda/grayskull/issues/582
* Add missing dependencies of fsspec-xrootd, requests, aiohttp.
* Add 'pip check' to tests.
* Add conda-forge/scikit-hep as feedstock maintainers.
* Use 'pypi.org'.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
