### PR TITLE
MNT: skip fsspec-xrootd in windows

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,9 +34,6 @@ requirements:
     - vector >=1.4.1,!=1.6.0
     - correctionlib >=2.6.0
     - pyarrow >=6.0.0,<21.0.0
-    - if: not win
-      then:
-        - fsspec-xrootd >=0.2.3
     - matplotlib-base >=3
     - numba >=0.58.1
     - numpy >=1.22


### PR DESCRIPTION
`fsspec-xrootd` requires `xrootd` which doesn't exist on windows. That makes `coffea` uninstallable via `conda-forge` on windows. We should just ignore `fsspec-xrootd`  in windows even though it's pure python.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
